### PR TITLE
Fix for two generator errors during server install

### DIFF
--- a/server/lib/picky/generator.rb
+++ b/server/lib/picky/generator.rb
@@ -44,7 +44,7 @@ module Picky
     
     def initialize
       @types = {
-        project: [Project, :project_name]
+        project => [Project, :project_name]
       }
     end
     
@@ -148,7 +148,7 @@ module Picky
       rescue Errno::EISDIR
         # p "EISDIR #{filename} -> #{target}"
         FileUtils.rm target
-        FileUtils.mkdir_p target unless Dir.exists?(target)
+        FileUtils.mkdir_p target unless File.exist?(target)
         created target
       rescue Errno::EEXIST
         # p "EEXIST #{filename} -> #{target}"


### PR DESCRIPTION
I'm running REE (`ruby 1.8.7 (2009-06-12 patchlevel 174) [i686-darwin10.4.0], MBARI 0x6770, Ruby Enterprise Edition 2009.10`) and ran into two errors running `picky project proj_name`, one because of a Ruby syntax error (looks like a Javascript switching issues :)) and one due to a problem on directory checks. 
