### PR TITLE
Untitled

### DIFF
--- a/server/lib/picky/cores.rb
+++ b/server/lib/picky/cores.rb
@@ -83,7 +83,7 @@ class Cores # :nodoc:all
   #   os_name => lambda_which_returns_a_number_of_cores
   #
   @@number_of_cores = {
-    'darwin' => lambda { `system_profiler SPHardwareDataType | grep 'Total Number Of Cores'`.gsub(/[^\d]/, '') },
+    'darwin' => lambda { `system_profiler SPHardwareDataType | grep 'Total Number of Cores'`.gsub(/[^\d]/, '') },
     'linux'  => lambda { `grep -ci ^processor /proc/cpuinfo` }
   }
   def self.os_to_core_mapping


### PR DESCRIPTION
This was happening on Snow Leopard. It was causing the "rake index" task to fail and the rest of the tutorial to not work correctly (since the index was never being generated).
