### PR TITLE
Issue #25

### DIFF
--- a/client/lib/picky-client/client.rb
+++ b/client/lib/picky-client/client.rb
@@ -116,17 +116,6 @@ module Picky
 
 end
 
-# Extend hash with to_query method.
+# Extend object with to_query method.
 #
-begin
-  require 'active_support/core_ext/object/to_query'
-rescue LoadError
-
-end
-class Hash
-  def to_query namespace = nil
-    collect do |key, value|
-      value.to_query(namespace ? "#{namespace}[#{key}]" : key)
-    end.sort * '&'
-  end
-end
+require 'active_support/core_ext/object/to_query'

--- a/client/picky-client.gemspec
+++ b/client/picky-client.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ['README.rdoc']
 
   s.add_dependency('yajl-ruby', '>= 0.7.8')
+  s.add_dependency('activesupport', '>=3.0.0')
 end


### PR DESCRIPTION
Hi,
I've checked `active_support/core_ext/object/to_query.rb` file history and it doesn't exist in 2.3 (https://github.com/rails/rails/blob/2-3-stable/activesupport/lib/active_support/core_ext/object/to_query.rb).

Cheers.
