### PR TITLE
Fix bundle load errors when compiled with clang

### DIFF
--- a/server/lib/performant.c
+++ b/server/lib/performant.c
@@ -2,7 +2,7 @@
 
 // Copying internal ruby methods.
 //
-inline VALUE rb_ary_elt(ary, offset)
+static inline VALUE rb_ary_elt(ary, offset)
     VALUE ary;
     long offset;
 {
@@ -12,7 +12,7 @@ inline VALUE rb_ary_elt(ary, offset)
     }
     return RARRAY_PTR(ary)[offset];
 }
-inline VALUE ary_make_hash(ary1, ary2)
+static inline VALUE ary_make_hash(ary1, ary2)
     VALUE ary1, ary2;
 {
     VALUE hash = rb_hash_new();
@@ -28,7 +28,7 @@ inline VALUE ary_make_hash(ary1, ary2)
     }
     return hash;
 }
-inline VALUE rb_ary_length(VALUE ary) {
+static inline VALUE rb_ary_length(VALUE ary) {
   long length = RARRAY_LEN(ary);
   return LONG2NUM(length);
 }
@@ -37,7 +37,7 @@ inline VALUE rb_ary_length(VALUE ary) {
 //  * orders the arrays by ascending size, small to large.
 //  * calls the & consecutively for all arrays.
 //
-inline VALUE memory_efficient_intersect(VALUE self, VALUE unsorted_array_of_arrays) {
+static inline VALUE memory_efficient_intersect(VALUE self, VALUE unsorted_array_of_arrays) {
   // Counters.
   //
   long i, j;


### PR DESCRIPTION
Clang defaults to C99 mode where inline is treated differently
to the gcc standard.

see: http://clang.llvm.org/compatibility.html#inline

This problem manifests as:

```
dlopen(/Users/andy/.gem/ruby/1.9.1/gems/picky-4.6.3/lib/performant.bundle, 9): Symbol not found: _memory_efficient_intersect
  Referenced from: /Users/andy/.gem/ruby/1.9.1/gems/picky-4.6.3/lib/performant.bundle
  Expected in: flat namespace
 in /Users/andy/.gem/ruby/1.9.1/gems/picky-4.6.3/lib/performant.bundle - /Users/andy/.gem/ruby/1.9.1/gems/picky-4.6.3/lib/performant.bundle
```
