### PR TITLE
add injectable ranges to categories

### DIFF
--- a/server/lib/picky/category.rb
+++ b/server/lib/picky/category.rb
@@ -48,6 +48,7 @@ module Picky
       #
       @source    = Source.from options[:source], true, @index.name
       @tokenizer = Tokenizer.from options[:indexing], @index.name, name
+      @ranger    = options[:ranging] || Range
 
       @key_format = options.delete :key_format
       @backend    = options.delete :backend

--- a/server/lib/picky/category_indexed.rb
+++ b/server/lib/picky/category_indexed.rb
@@ -23,7 +23,9 @@ module Picky
         #
         # TODO Possible to speed up more?
         #
-        range.inject(nil) do |sum, text|
+        ranger = @ranger.new *range
+
+        ranger.inject(nil) do |sum, text|
           weight = bundle.weight(text)
           weight && (weight + (sum || 0)) || sum
         end
@@ -40,7 +42,9 @@ module Picky
         # Adding all to an array, then flattening
         # is faster than using ary + ary.
         #
-        range.inject([]) do |result, text|
+        ranger = @ranger.new *range
+
+        ranger.inject([]) do |result, text|
           # It is 30% faster using the empty check
           # than just << [].
           #

--- a/server/lib/picky/query/token.rb
+++ b/server/lib/picky/query/token.rb
@@ -201,7 +201,7 @@ module Picky
       end
       def rangify
         if @text.include? @@range_character
-          @range = Range.new *@text.split(@@range_character, 2)
+          @range = @text.split(@@range_character, 2)
         end
       end
       def range


### PR DESCRIPTION
This patch adds the :ranging option to the category constructor. Allowing library users
to inject custom range generators.
