### PR TITLE
Make sure that the cache_path is created for Sqlite3 files

### DIFF
--- a/server/Rakefile
+++ b/server/Rakefile
@@ -1,2 +1,3 @@
+`rm -r spec/temp/*`
 load File.expand_path '../tasks/specs.rake', __FILE__
 load File.expand_path '../tasks/stats.rake', __FILE__

--- a/server/lib/picky/backends/sqlite/basic.rb
+++ b/server/lib/picky/backends/sqlite/basic.rb
@@ -47,7 +47,7 @@ module Picky
         end
 
         def lazily_initialize_client
-          @db ||= SQLite3::Database.new cache_path
+          @db ||= begin create_directory cache_path; SQLite3::Database.new cache_path end
         end
 
         def dump_sqlite internal

--- a/server/spec/lib/backends/sqlite/array_spec.rb
+++ b/server/spec/lib/backends/sqlite/array_spec.rb
@@ -5,7 +5,7 @@ require 'sqlite3'
 describe Picky::Backends::SQLite::Array do
 
   context 'hash-based indexes' do
-    let(:db) { described_class.new 'spec/temp/some/cache/path/to/file' }
+    let(:db) { described_class.new 'spec/temp/some/other/cache/path/to/file' }
 
     describe 'dump' do
       it 'forwards to the given hash' do
@@ -67,13 +67,13 @@ describe Picky::Backends::SQLite::Array do
 
     describe 'to_s' do
       it 'returns the cache path with the default file extension' do
-        db.to_s.should == 'Picky::Backends::SQLite::Array(spec/temp/some/cache/path/to/file.sqlite3)'
+        db.to_s.should == 'Picky::Backends::SQLite::Array(spec/temp/some/other/cache/path/to/file.sqlite3)'
       end
     end
   end
 
   context 'hash-based indexes' do
-    let(:db) { described_class.new 'spec/temp/some/cache/path/to/file', realtime: true }
+    let(:db) { described_class.new 'spec/temp/some/other/cache/path/to/file', realtime: true }
 
     describe 'dump' do
       it 'forwards to the given hash' do
@@ -135,7 +135,7 @@ describe Picky::Backends::SQLite::Array do
 
     describe 'to_s' do
       it 'returns the cache path with the default file extension' do
-        db.to_s.should == 'Picky::Backends::SQLite::Array(spec/temp/some/cache/path/to/file.sqlite3)'
+        db.to_s.should == 'Picky::Backends::SQLite::Array(spec/temp/some/other/cache/path/to/file.sqlite3)'
       end
     end
   end

--- a/server/spec/lib/backends/sqlite/value_spec.rb
+++ b/server/spec/lib/backends/sqlite/value_spec.rb
@@ -5,7 +5,7 @@ require 'sqlite3'
 describe Picky::Backends::SQLite::Value do
 
   context 'hash-based indexes' do
-    let(:db) { described_class.new 'spec/temp/some/cache/path/to/file' }
+    let(:db) { described_class.new 'spec/temp/some/other/cache/path/to/file' }
 
     describe 'dump' do
       it 'forwards to the given hash' do
@@ -67,7 +67,7 @@ describe Picky::Backends::SQLite::Value do
 
     describe 'to_s' do
       it 'returns the cache path with the default file extension' do
-        db.to_s.should == 'Picky::Backends::SQLite::Value(spec/temp/some/cache/path/to/file.sqlite3)'
+        db.to_s.should == 'Picky::Backends::SQLite::Value(spec/temp/some/other/cache/path/to/file.sqlite3)'
       end
     end
   end


### PR DESCRIPTION
When you try to use the SQLite backend and don't have the necessary paths created, Picky will crash because SQLite can't open (or create) the right file. This is because the directory is only created in #reset, but the file is opened in lazily_initialize_client. The specs ran through because the temporary directory was not cleaned, thus leaving the paths intact. Also, another spec would create the necessary path. This code implements a fix and also fixes the specs.
