### PR TITLE
Use https://rubygems.org and not :rubygems

### DIFF
--- a/activemodel/Gemfile
+++ b/activemodel/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "https://rubygems.org"
 

--- a/client/Gemfile
+++ b/client/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem 'rake'
 gem 'rack'

--- a/live/Gemfile
+++ b/live/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem 'rake'
 gem 'rack'

--- a/statistics/Gemfile
+++ b/statistics/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source "https://rubygems.org"
 
 gem 'rake'
 gem 'rack'


### PR DESCRIPTION
Since the security breach it's better to keep this stuff seriously.
