### PR TITLE
Also ignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ config
 
 coverage
 .rbenv*
+.ruby-version
 sandbox/


### PR DESCRIPTION
This is the modern alternative to .rvmrc and .rbenv-version.
