### PR TITLE
Allow "from" option inside index to be a lambda

### DIFF
--- a/server/lib/picky/category_realtime.rb
+++ b/server/lib/picky/category_realtime.rb
@@ -17,7 +17,11 @@ module Picky
     # given object.
     #
     def add object, where = :unshift
-      add_text object.id, object.send(from), where
+      if from.respond_to? :call
+        add_text object.id, from.call(object), where
+      else
+        add_text object.id, object.send(from), where
+      end
     end
 
     # Removes the object's id, and then

--- a/web/source/documentation/_category.html.md
+++ b/web/source/documentation/_category.html.md
@@ -211,10 +211,16 @@ Sometimes though, the model has not the right names. Say, you have an italian bo
 
     Index.new :books do
       source { Libro.order('autore DESC') }
-    
+
       category :title,  :from => :titulo
       category :author, :from => :autore
       category :isbn
+    end
+
+You can also populate the index at runtime using a lambda. The required argument inside the lambda is the object being added to the index.
+
+    Index.new :books do
+      category :authors, :from => lambda { |book| book.authors.map(&:name) }
     end
 
 ### Option key_format{#indexes-categories-keyformat}


### PR DESCRIPTION
This allows users to populate the index at runtime. This way,
when you are using custom field names they don't need to be
present inside the model, but can be defined just for the
index.

I consider this pull request to be a work in progress since it
is missing specs. I just could not get the specs to work for
the server (see #110). This change does however work for
me when I use the gem locally.

Also I don't know yet where you want me to write documentation
for this beside the web source. Also glad to hear if anything
should be done differently.
