### PR TITLE
Handle rails 4 default logger, remove deprecation warning

### DIFF
--- a/server/lib/picky.rb
+++ b/server/lib/picky.rb
@@ -20,7 +20,11 @@ module Picky
   #
   # TODO Remove active support, as a goal.
   #
-  require 'active_support/core_ext/logger'
+  begin
+    require 'active_support/logger' # Require Rails 4 recommanded logger
+  rescue LoadError
+    require 'active_support/core_ext/logger'
+  end
   require 'active_support/core_ext/object/blank'
   require 'active_support/multibyte'
   require 'multi_json'


### PR DESCRIPTION
Hi Floere,

with Rails 4, requiring 'active_support/core_ext/logger' gives a deprecation warning. I PR this smooth transition to the new Logger file. 
