### PR TITLE
strscan is still required in ruby 2.1

### DIFF
--- a/server/lib/picky.rb
+++ b/server/lib/picky.rb
@@ -33,7 +33,7 @@ module Picky
   # TODO Still required with Ruby 2.1?
   # 
   # require 'fileutils'
-  # require 'strscan'
+  require 'strscan'
   
   # Check if platform specific modifiers need to be installed.
   #

--- a/server/spec/lib/picky_spec.rb
+++ b/server/spec/lib/picky_spec.rb
@@ -11,4 +11,16 @@ describe Picky do
   #   Encoding.default_internal.should == Encoding::UTF_8
   # end
   
+  it 'loads in a simple ruby environment with the defined requirements' do
+    #TODO Picky.root is set to /spec/temp in spec_helper, so is this the "best" way?
+    load_path   = File.expand_path('../../../lib', __FILE__)
+    ruby        = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']).sub(/.*\s.*/m, '"\&"')
+
+    simple_load = <<-COMMAND
+      #{ruby} -I #{load_path} -r picky -e "puts 'OK'"
+    COMMAND
+    
+    IO.popen(simple_load, err: [:child, :out]).readline.strip.should == 'OK'
+  end
+  
 end


### PR DESCRIPTION
Hey there

This is a fix for `NameError: uninitialized constant Picky::StringScanner` when loading picky server. Started getting this error in my picky sinatra server. 

So `require 'strscan'` is still required in 2.1.

Added a spec to make sure picky loads without errors by itself.

Happy Easter!
