### PR TITLE
pass the block explicitly

### DIFF
--- a/server/lib/picky/index.rb
+++ b/server/lib/picky/index.rb
@@ -117,7 +117,7 @@ module Picky
     #     result_identifier :my_special_results
     #   end
     #
-    def initialize name
+    def initialize name, &proc
       @name       = name.intern
       @categories = Categories.new
 
@@ -125,7 +125,7 @@ module Picky
       #
       Indexes.register self
 
-      instance_eval(&Proc.new) if block_given?
+      instance_eval(&proc) if block_given?
     end
     
     # Provide hints for Picky so it can optimise.

--- a/server/lib/picky/search.rb
+++ b/server/lib/picky/search.rb
@@ -37,10 +37,10 @@ module Picky
     #            [:title, :isbn] => +1
     #   end
     #
-    def initialize *indexes
+    def initialize *indexes, &proc
       @indexes = Query::Indexes.new *indexes
 
-      instance_eval(&Proc.new) if block_given?
+      instance_eval(&proc) if block_given?
 
       @tokenizer ||= Tokenizer.searching # THINK Not dynamic. Ok?
       @boosts    ||= Query::Boosts.new


### PR DESCRIPTION
I used this gem, so got this message.


```
/PROJECT_PATH/vendor/bundle/ruby/2.7.0/gems/picky-4.31.3/lib/picky/index.rb:128: warning: Capturing the given block using Kernel#proc is deprecated; use `&block` instead
```

Since ruby 2.7, it causes a bug, so a warning is displayed.
https://bugs.ruby-lang.org/issues/15539

Warnings are mixed in when displaying user information etc. using API, so I want to prevent it from appearing.