### PR TITLE
Fixes for modern Ruby/systems

### DIFF
--- a/generators/prototypes/all_in_one/sinatra/Gemfile
+++ b/generators/prototypes/all_in_one/sinatra/Gemfile
@@ -14,7 +14,6 @@ gem 'haml'
 gem 'picky', '~> 4.0'
 gem 'rake'
 gem 'rack'
-gem 'rack_fast_escape', '2009.06.24' # Optional.
 gem 'text'
 gem 'multi_json'
 

--- a/generators/prototypes/server/sinatra/Gemfile
+++ b/generators/prototypes/server/sinatra/Gemfile
@@ -5,7 +5,6 @@ gem 'sinatra'
 gem 'tilt', '~> 1.4.1'
 gem 'rake'
 gem 'rack'
-gem 'rack_fast_escape', '2009.06.24' # Optional.
 gem 'text'
 gem 'multi_json'
 

--- a/memory_test/Gemfile
+++ b/memory_test/Gemfile
@@ -1,3 +1,5 @@
+source 'http://rubygems.org'
+
 gem 'picky', ENV['PICKY_VERSION']
 gem 'yajl-ruby', :require => 'yajl'
 gem 'procrastinate'

--- a/memory_test/Gemfile.lock
+++ b/memory_test/Gemfile.lock
@@ -1,4 +1,5 @@
 GEM
+  remote: http://rubygems.org/
   specs:
     activesupport (3.2.9)
       i18n (~> 0.6)
@@ -28,3 +29,6 @@ DEPENDENCIES
   picky
   procrastinate
   yajl-ruby
+
+BUNDLED WITH
+   2.4.22

--- a/memory_test/Gemfile.lock
+++ b/memory_test/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     state_machine (0.9.4)
     text (1.2.1)
     url_escape (2009.06.24)
-    yajl-ruby (1.1.0)
+    yajl-ruby (1.4.3)
 
 PLATFORMS
   ruby

--- a/server/lib/picky.rb
+++ b/server/lib/picky.rb
@@ -26,7 +26,6 @@ module Picky
   require 'active_support/core_ext/object/blank'
   require 'active_support/multibyte'
   require 'multi_json'
-  require 'rack_fast_escape' if defined? Rack
   
   # TODO Still required with Ruby 2.1?
   # 

--- a/server/picky.gemspec
+++ b/server/picky.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activesupport'
   s.add_runtime_dependency 'multi_json', '~> 1.3'
-  s.add_runtime_dependency 'rack_fast_escape', '~> 2009.0'
   # s.add_runtime_dependency 'google_hash', '~> 0.8'
 
   # Optional dependencies.

--- a/server/test_project/Gemfile
+++ b/server/test_project/Gemfile
@@ -5,7 +5,6 @@ gem 'rspec'
 gem 'activesupport'
 gem 'sinatra'
 gem 'rack'
-gem 'rack_fast_escape', '2009.06.24' # Optional.
 gem 'text'
 gem 'multi_json'
 


### PR DESCRIPTION
These are a couple quick fixes for modern Ruby and compilers.  This *should* unblock updating to Ruby 3.2+ in our project.